### PR TITLE
[FEAT] Allow introspection directive on unions

### DIFF
--- a/src/dogs-and-agents.ts
+++ b/src/dogs-and-agents.ts
@@ -20,11 +20,29 @@ export function create() {
       POODLE @introspection
       BULLDOG @introspection
     }
+    
+    enum IssueType @introspection(fields: true) {
+        FLEAS
+        HEARTWORMS
+    }
+    
+    union Issue @introspection = Fleas | Heartworms
+    
+    type Fleas @introspection(fields: true) {
+        type: IssueType!
+        bathed: Boolean!
+    }
+    
+    type Heartworms @introspection {
+        type: IssueType! @introspection
+        surgeryRequired: Boolean!
+    }
 
     type Dog @introspection(fields: true) {
       name: String!
       age: Int!
       breed: Breed!
+      issues: [Issue!]!
     }
 
     type Agent {
@@ -92,6 +110,13 @@ export function create() {
         return 'Woof!';
       },
     },
+    Issue: {
+      __resolveType: (parent: { type: 'FLEAS' | 'HEARTWORMS' }) => {
+        if (parent.type === 'FLEAS') return 'Fleas';
+        if (parent.type === 'HEARTWORMS') return 'Heartworms';
+        throw new Error('Undefined Issue Type');
+      }
+    }
   };
 
   const apolloServer = new ApolloServer({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,7 +8,11 @@ describe('directive', () => {
       'CacheControlScope',
       { kind: 'ENUM', name: 'Size', fields: ['SMALL', 'MEDIUM', 'LARGE'] },
       { kind: 'ENUM', name: 'Breed', fields: ['POODLE', 'BULLDOG'] },
-      { kind: 'OBJECT', name: 'Dog', fields: ['name', 'age', 'breed'] },
+      { kind: 'ENUM', name: 'IssueType', fields: ['FLEAS', 'HEARTWORMS'] },
+      { kind: 'UNION', name: 'Issue', fields: ['Fleas', 'Heartworms'] },
+      { kind: 'OBJECT', name: 'Fleas', fields: ['type', 'bathed'] },
+      { kind: 'OBJECT', name: 'Heartworms', fields: ['type'] },
+      { kind: 'OBJECT', name: 'Dog', fields: ['name', 'age', 'breed', 'issues'] },
       { kind: 'OBJECT', name: 'Query', fields: ['dogs'] },
       { kind: 'OBJECT', name: 'Mutation', fields: ['bark'] },
     ]);


### PR DESCRIPTION
Current implementation breaks on unions. This PR addresses that

(on a side note, would really like to get this in to our software release in ~3 weeks without having to locally maintain)